### PR TITLE
Fix for new UI of Safari 12

### DIFF
--- a/csv-toicloudkeychain.applescript
+++ b/csv-toicloudkeychain.applescript
@@ -40,7 +40,7 @@ repeat with i from 1 to length of recs
 				
 				click button "Add" of group 1 of group 1 of it
 				-- write fields
-				tell last row of table 1 of scroll area of group 1 of group 1 of it
+				tell sheet 1 of it
 					set value of text field 1 of it to kcURL
 					keystroke tab
 					set value of text field 2 of it to kcUsername


### PR DESCRIPTION
The UI elements have moved around in Safari 12 from Safari 11.
Resuting in errors along the lines of:
"System Events got an error: Can’t set value of missing value
to X.com from value of missing value", stopping this from working.

This updates the script for traversing the new UI elements.